### PR TITLE
added helper controller_path(rails way) and changed controller_files

### DIFF
--- a/cgi-bin/lib/GG.pm
+++ b/cgi-bin/lib/GG.pm
@@ -89,16 +89,7 @@ sub startup {
 
   $routes->any('/')->to("Texts#text_main_item", alias => 'main')->name('main');
 
-  $routes->any('/news/list')->to(
-    "Texts#texts_list",
-    alias      => 'news',
-    key_razdel => "news",
-    admin_name => 'Новости'
-  )->name('news_list');
-
-  $routes->any('/news/:list_item_alias', [list_item_alias => $self->alias_re])
-    ->to("Texts#text_list_item", alias => 'news', key_razdel => "news")
-    ->name('news_item');
+  $routes->texts('news', 'Новости и акции');
 
   $routes->any("/images")->to(
     "Images#images_list",

--- a/cgi-bin/lib/GG/Plugins/Init.pm
+++ b/cgi-bin/lib/GG/Plugins/Init.pm
@@ -63,6 +63,7 @@ sub register {
   $app->plugin('dbi', $conf);
   $app->plugin('loadmodels' => { namespace => 'GG::Model' });
   $app->plugin('vfe') if $conf->{'vfe_enabled'};
+  $app->plugin('shortcuts');
 
   if ( $conf->{robokassa}
     && ref $conf->{robokassa}

--- a/cgi-bin/lib/GG/Plugins/Shortcuts.pm
+++ b/cgi-bin/lib/GG/Plugins/Shortcuts.pm
@@ -1,0 +1,52 @@
+package GG::Plugins::Shortcuts;
+
+use utf8;
+
+use Mojo::Base 'Mojolicious::Plugin';
+
+sub register {
+  my ($self, $app, $opt) = @_;
+
+  $app->routes->add_shortcut(resource => sub {
+    my ($r, $name, $controller) = @_;
+    $controller ||= $name;
+    # Prefix for resource
+    my $resource = $r->any("/$name")->to("$name#");
+
+    # Render a list of resources
+    $resource->get->to('#index')->name($name);
+
+    # Render a form to create a new resource (submitted to "store")
+    $resource->get('/create')->to('#create')->name("create_$name");
+
+    # Store newly created resource (submitted by "create")
+    $resource->post->to('#store')->name("store_$name");
+
+    # Render a specific resource
+    $resource->get('/:id')->to('#show')->name("show_$name");
+
+    # Render a form to edit a resource (submitted to "update")
+    $resource->get('/:id/edit')->to('#edit')->name("edit_$name");
+
+    # Store updated resource (submitted by "edit")
+    $resource->put('/:id')->to('#update')->name("update_$name");
+
+    # Remove a resource
+    $resource->delete('/:id')->to('#remove')->name("remove_$name");
+
+    return $resource;
+  });
+
+  $app->routes->add_shortcut(texts => sub {
+    my ($r, $name, $admin_name) = @_;
+
+    my $resource = $r->any("/$name")->to("Texts#");
+
+    $resource->any('/list')->to('#texts_list', admin_name => $admin_name, alias => $name, key_razdel => $name)->name($name."_list");
+    $resource->any('/:list_item_alias', [list_item_alias => $app->alias_re])->to('#text_list_item', alias => $name, key_razdel => $name)->name($name."_item");
+
+
+    return $resource;
+  });
+}
+1;

--- a/cgi-bin/lib/GG/Plugins/UtilHelpers.pm
+++ b/cgi-bin/lib/GG/Plugins/UtilHelpers.pm
@@ -372,8 +372,6 @@ sub register {
       my @js_files  = ();
       my @css_files = ();
       if (-e $static_path . '/js/controllers/' . $controller . '.js') {
-
-        #$self->js_files( '/js/controllers/'.$controller.'.js' );
         push @js_files, '/js/controllers/' . $controller . '.js';
       }
       if (-d $static_path . '/js/controllers/' . $controller) {

--- a/cgi-bin/lib/GG/Plugins/UtilHelpers.pm
+++ b/cgi-bin/lib/GG/Plugins/UtilHelpers.pm
@@ -5,6 +5,7 @@ use Mojo::Base 'Mojolicious::Plugin';
 
 use File::stat;
 use Mojo::ByteStream;
+use Mojo::Util qw(decamelize);
 
 sub register {
   my ($self, $app) = @_;
@@ -30,6 +31,15 @@ sub register {
       $js;
     }
   );
+
+  $app->helper(controller_path => sub {
+    my $self = shift;
+    my $controller = shift // $self->stash('controller');
+    $controller = decamelize $controller;
+    $controller =~ s/-/\//gi;
+
+    return $controller;
+  });
 
   $app->helper(vu => sub { shift->tx->req->url->path->parts->[+shift] || '' });
 
@@ -356,7 +366,7 @@ sub register {
       my $self = shift;
       return unless my $controller = shift || $self->stash->{controller};
 
-      $controller = lc $controller;
+      $controller = $self->controller_path($controller);
       my $static_path = $self->static_path;
 
       my @js_files  = ();

--- a/cgi-bin/misc/server/perlmagick.sh
+++ b/cgi-bin/misc/server/perlmagick.sh
@@ -35,8 +35,9 @@ fi
 
 mkdir -p $TOP
 cd "$TOP"
-wget -c http://www.imagemagick.org/download/ImageMagick.tar.gz
-tar xzvf ImageMagick.tar.gz
+
+wget -c https://www.imagemagick.org/download/releases/ImageMagick-6.8.8-10.tar.xz
+tar xf ImageMagick-6.8.8-10.tar.xz
 cd ImageMagick* # this isn't exactly clean
 
 


### PR DESCRIPTION
New helper - controller_path. Like in Rails.
`Catalog::Basket.pm` -> `catalog/basket`
`Catalog::Basket::Checkout.pm` -> `catalog/basket/checkout`

Now, `controller_files` helper get `$controller` var from this helper.
It means, if you are in Basket and using `GG::Content::Catalog::Basket.pm`, 
`controller_files` would load `catalog/basket.js` and `catalog/basket/*`